### PR TITLE
Clarify macOS shortcut guidance in calibration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If YAML is wrong, loader returns explicit errors. Common examples:
 - `lanes[0].px_to_meter must be > 0`
 
 ### Key input notes (OpenCV windows)
-- macOS: use single keys (`u/z/n/r/s`, `Enter`, `ESC`) instead of modifier combos.
+- macOS: try single keys first (`u/z/n/r/s`, `Enter`, `ESC`). If your setup only captures shortcuts with `Cmd`, use `Cmd+u/z/n/r/s`.
 - Windows/Linux: make sure the OpenCV window is focused before typing shortcuts.
 
 ### Docs

--- a/app/calibrate/roi.py
+++ b/app/calibrate/roi.py
@@ -283,7 +283,10 @@ def main() -> None:
     step_colors = build_step_colors(labels)
 
     print("Point order guidance: click points clockwise around each polygon.")
-    print("Mac shortcut tip: OpenCV windows reliably support single keys (u/z/n/r/s).")
+    print(
+        "Mac shortcut tip: try single keys first (u/z/n/r/s). "
+        "If not captured, use Cmd+u/z/n/r/s."
+    )
 
     capture = open_video_source(args.video)
     if capture is None or not capture.isOpened():

--- a/docs/02_calibration.md
+++ b/docs/02_calibration.md
@@ -30,8 +30,9 @@ Point direction recommendation:
 - Click points clockwise for every polygon (`view`, `calibration`, and each lane).
 
 Mac note:
-- In OpenCV windows, modifier shortcuts (for example `Cmd+Z`) are not always captured consistently.
-- Use single-key shortcuts above for stable behavior.
+- Try single-key shortcuts first.
+- On some macOS environments, key input is only detected with `Cmd` pressed.
+- If single keys do not work, use `Cmd+u/z/n/r/s`.
 
 ## Scale calibration (`px_to_meter`)
 Each lane needs `px_to_meter = meters / pixels`.


### PR DESCRIPTION
## Summary
- update README key-input guidance for macOS to reflect real-world cases where `Cmd+key` is required
- update calibration guide with the same fallback guidance
- update ROI CLI startup message to match docs (`single key first`, fallback to `Cmd+u/z/n/r/s`)

## Testing
- `python3 -m unittest discover -s tests`
